### PR TITLE
style: Switch JIRA ticket and ConvComm prefix

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
-<!-- Title should start with the JIRA ticket in square brackets. This will automatically link the PR in JIRA. -->
-<!-- Example: "[VUMM-73] fix: Allow creation of groups with no members" -->
+<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
+<!-- Example: "fix: [VUMM-73] Allow creation of groups with no members" -->
 
 ## Impact and Context
 <!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
 <!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
-<!-- Example: "fix: [VUMM-73] Allow creation of groups with no members" -->
+<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->
 
 ## Impact and Context
 <!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should start with the JIRA ticket in square brackets. This will automatically link the PR in JIRA. -->
<!-- Example: "[JIRA-123] fix: Allow creation of groups with no members" -->

## Impact and Context

To comply with the first point of [the Conventional Commit spec](https://www.conventionalcommits.org/en/v1.0.0/#specification), I'm suggesting moving the commit type prefix to the very beginning, and placing the JIRA ticket number after.

I'm also changing the example from `VUMM-73` to `JIRA-123`, because having a real ticket number in your PR description (even commented out) causes the Jira bot to attempt to append a reference hyperlink for it, which is a bit of a nuisance:

![Screen Shot 2022-01-07 at 4 07 46 PM](https://user-images.githubusercontent.com/96442646/148622364-716d468d-d720-47ad-8f48-74f27b48133f.png)

![Screen Shot 2022-01-07 at 4 05 04 PM](https://user-images.githubusercontent.com/96442646/148622367-13e6cef3-a6b0-4933-9768-5954d2930999.png)

## Risks and Area of Effect

Low risk: JIRA does not require the ticket number to be at the beginning

![Screen Shot 2022-01-07 at 4 02 14 PM](https://user-images.githubusercontent.com/96442646/148621996-edbac2be-daad-4b11-8525-e4cc4eacad7f.png)

High AoE: Affects all our tickets!

## Testing

See the screenshot in **Risks and Area of Effect**.

## How to Revert

Revert this PR.